### PR TITLE
Pin nanobind==0.0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     "scikit-build==0.14.0",
     "cmake>=3.18",
-    "nanobind>=0.0.5",
+    "nanobind==0.0.7",
     "ninja; platform_system!='Windows'"
 ]
 


### PR DESCRIPTION
nanobind 0.0.8 contains a workaround for the typing issue, so installing this package no longer demonstrates the problem